### PR TITLE
ビルドしてからNetlifyにデプロイするGitHub Actionsの設定を追加

### DIFF
--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -1,0 +1,47 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "10.x"
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install
+        run: yarn install
+
+      - name: Build site
+        run: yarn generate:deploy
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.0
+        with:
+          publish-dir: "./dist"
+          production-branch: master
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #8 

## 📝 関連する issue / Related Issues

PRのサンプルです。

- https://github.com/Tiryoh/tottori-covid19/pull/1
    - ビルドログ：https://github.com/Tiryoh/tottori-covid19/runs/581807912?check_suite_focus=true
    - マージ後のビルドログ：https://github.com/Tiryoh/tottori-covid19/runs/582299940?check_suite_focus=true

このようにNetlify同様にテストデプロイ後のURLが[コメントでつきます](https://github.com/Tiryoh/tottori-covid19/pull/1#issuecomment-612746557)。

[![Image from Gyazo](https://i.gyazo.com/0ed712401631b22ace0b25df6414f447.png)](https://gyazo.com/0ed712401631b22ace0b25df6414f447)

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- https://github.com/nwtgck/actions-netlify でNetlifyにデプロイするためのGitHub Actionsの設定を追加

以下の記事を参考に`NETLIFY_AUTH_TOKEN`と`NETLIFY_SITE_ID`の設定をお願いいたします。

https://qiita.com/nwtgck/items/e9a355c2ccb03d8e8eb0