### PR TITLE
GitHub Actionsで実行されたコミットではデプロイされない問題を修正

### DIFF
--- a/.github/workflows/deploy-to-netlify.yml
+++ b/.github/workflows/deploy-to-netlify.yml
@@ -1,7 +1,6 @@
 name: Deploy
 
 on:
-  deployment:
   push:
     branches:
       - master

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -9,6 +9,8 @@ jobs:
       QUERENT_DATASET_URL: https://raw.githubusercontent.com/tottori-covid19/dataset/master/tottori/querent.csv
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GIT_TOKEN }}
       - run: curl -sL -o tool/downloads/tottori/inspection.csv "${INSPECTION_DATASET_URL}"
       - run: curl -sL -o tool/downloads/tottori/querent.csv "${QUERENT_DATASET_URL}"
       - id: git_status
@@ -29,10 +31,4 @@ jobs:
             -c "user.name=${GITHUB_ACTOR}" \
             -c "user.email=${GITHUB_ACTOR}@users.noreply.github.com" \
             commit -m "${{ github.workflow }}" \
-          && git push origin HEAD \
-          && curl \
-            -H "Authorization: token ${{ github.token }}" \
-            -H "Accept: application/vnd.github.ant-man-preview+json" \
-            -H "Content-Type: application/json" \
-            -d "{\"ref\": \"${GITHUB_REF}\"}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments"
+          && git push origin HEAD

--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -8,6 +8,8 @@ jobs:
       NEWS_FEED_URL: https://www.pref.tottori.lg.jp/services/rdf/rss10/589717.xml
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GIT_TOKEN }}
       - run: |
           curl \
             -sL "https://api.rss2json.com/v1/api.json?rss_url=${NEWS_FEED_URL}" \
@@ -31,10 +33,4 @@ jobs:
         run: |
           git add data/news.json \
           && git -c "user.name=${GITHUB_ACTOR}" -c "user.email=${GITHUB_ACTOR}@users.noreply.github.com" commit -m update-news \
-          && git push origin HEAD \
-          && curl \
-            -H "Authorization: token ${{ github.token }}" \
-            -H "Accept: application/vnd.github.ant-man-preview+json" \
-            -H "Content-Type: application/json" \
-            -d "{\"ref\": \"${GITHUB_REF}\"}" \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/deployments"
+          && git push origin HEAD


### PR DESCRIPTION
deploymentイベントをgithub.tokenで発報してもGitHub Actionsは実行されなかったので、Personal access tokenを使う

( https://github.com/tottori-covid19/covid19/pull/10#issuecomment-613232054 より)

public_repo スコープをもつ秘匿情報 GIT_TOKEN を使ってコミットするように変更しました