### PR TITLE
tottori-covid19.netlify.app に変更

### DIFF
--- a/assets/locales/ja-Hira.json
+++ b/assets/locales/ja-Hira.json
@@ -264,7 +264,7 @@
   "※最新の情報はWebページをご覧ください": "※新（あたら）しい 情報（じょうほう）は Webページを 見（み）てください",
   "〇": "〇",
   "ogp": {
-    "og:image": "https://tottori-covid19.netlify.com/ogp.png"
+    "og:image": "https://tottori-covid19.netlify.app/ogp.png"
   },
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/jp/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=ja",

--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -264,7 +264,7 @@
   "※最新の情報はWebページをご覧ください": "※最新の情報はWebページをご覧ください",
   "〇": "〇",
   "ogp": {
-    "og:image": "https://tottori-covid19.netlify.com/ogp.png"
+    "og:image": "https://tottori-covid19.netlify.app/ogp.png"
   },
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/jp/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=ja",

--- a/assets/locales/th.json
+++ b/assets/locales/th.json
@@ -260,7 +260,7 @@
   "※最新の情報はWebページをご覧ください": "* โปรดตรวจสอบข้อมูลล่าสุดที่เว็บไซต์",
   "〇": "O",
   "ogp": {
-    "og:image": "https://tottori-covid19.netlify.com/ogp.png"
+    "og:image": "https://tottori-covid19.netlify.app/ogp.png"
   },
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/th/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=th",

--- a/assets/locales/vi.json
+++ b/assets/locales/vi.json
@@ -260,7 +260,7 @@
   "※最新の情報はWebページをご覧ください": "※Hãy cập nhật thông tin mới nhất trên trang Web.",
   "〇": "〇",
   "ogp": {
-    "og:image": "https://tottori-covid19.netlify.com/ogp.png"
+    "og:image": "https://tottori-covid19.netlify.app/ogp.png"
   },
   "https://marketingplatform.google.com/about/analytics/terms/jp/": "https://marketingplatform.google.com/about/analytics/terms/us/",
   "https://policies.google.com/privacy?hl=ja": "https://policies.google.com/privacy?hl=vi",

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -104,7 +104,7 @@ export default Vue.extend({
       link: [
         {
           rel: 'canonical',
-          href: `https://tottori-covid19.netlify.com${this.$route.path}`
+          href: `https://tottori-covid19.netlify.app${this.$route.path}`
         },
         {
           rel: 'stylesheet',
@@ -143,7 +143,7 @@ export default Vue.extend({
         {
           hid: 'og:url',
           property: 'og:url',
-          content: `https://tottori-covid19.netlify.com${this.$route.path}`
+          content: `https://tottori-covid19.netlify.app${this.$route.path}`
         },
         ogLocale,
         {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,7 +23,7 @@ const config: Configuration = {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://tottori-covid19.netlify.com/'
+        content: 'https://tottori-covid19.netlify.app/'
       },
       {
         hid: 'twitter:card',


### PR DESCRIPTION
- Netlifyサブドメイン機能のTLDの変更に伴い tottori-covid19.netlify.com→ [tottori-covid19.netlify.app](https://tottori-covid19.netlify.app) に変更しました